### PR TITLE
Hotfix/ Renamed this.domain to this.pbxDomain in webRTC module

### DIFF
--- a/lib/api/webRTC.js
+++ b/lib/api/webRTC.js
@@ -51,7 +51,7 @@ class WebRTC extends JsSIP.UA {
       instance_id: config.instanceId,
     });
 
-    this.domain = config.domain;
+    this.pbxDomain = config.domain;
 
     this.subscriptions = new Map();
     this.subscribeExpires = 600;
@@ -266,7 +266,7 @@ class WebRTC extends JsSIP.UA {
   }
 
   subscribeToUser(user, replacesSubscription) {
-    let uri = `sip:${user}@${this.domain}`;
+    let uri = `sip:${user}@${this.pbxDomain}`;
     uri = JsSIP.URI.parse(uri);
 
     const callId = replacesSubscription


### PR DESCRIPTION
# Hotfix
> Rename `this.domain` to `this.pbxDomain` in `lib/api/webRTC.js` module

This fixes an issue where overriding the variable `domain` in the context, causes node to believe you are using a legacy node.js domain instance, and tries to execute the `.enter` method, causing the following error:

> ```
> TypeError: domain.enter is not a function
>     at WebRTC.EventEmitter.emit (domain.js:547:10)
>     at WebRTC.onTransportConnecting (/home/andres/js/sipcentric-presence-nodejs/node_modules/jssip/lib/UA.js:947:8)
>     at Transport.connect (/home/andres/js/sipcentric-presence-nodejs/node_modules/jssip/lib/Transport.js:130:10)
>     at WebRTC.start (/home/andres/js/sipcentric-presence-nodejs/node_modules/jssip/lib/UA.js:142:23)
>     at /home/andres/js/sipcentric-presence-nodejs/index.js:146:23
>     at processTicksAndRejections (internal/process/task_queues.js:93:5)
>     at async Promise.all (index 0)
>     at async /home/andres/js/sipcentric-presence-nodejs/index.js:131:5
> ```

Closes #4 