### PR TITLE
Hotfix/ Parse uri variable in the resubscribeToUser method of the webRTC module using JsSIP.URI.parse

### DIFF
--- a/lib/api/webRTC.js
+++ b/lib/api/webRTC.js
@@ -288,7 +288,8 @@ class WebRTC extends JsSIP.UA {
   }
 
   resubscribeToUser(subscription) {
-    const uri = `sip:${subscription.toUser}@${subscription.toDomain}`;
+    let uri = `sip:${subscription.toUser}@${subscription.toDomain}`;
+    uri = JsSIP.URI.parse(uri);
 
     const options = {
       to_uri: uri,


### PR DESCRIPTION
# Hotfix
> Parse uri variable in the `resubscribeToUser` method of the `lib/api/webRTC.js` module using `JsSIP.URI.parse`

This fixes an issue where the following error is thrown when the user agent tries to resubscribe via the `resubscribeToUser` Method in the webRTC module:

>```
> TypeError: missing or invalid "uri" parameter
>     at new NameAddrHeader (/home/andres/js/sipcentric-presence-nodejs/node_modules/jssip/lib/NameAddrHeader.js:29:13)
>     at new OutgoingRequest (/home/andres/js/sipcentric-presence-nodejs/node_modules/jssip/lib/SIPMessage.js:61:15)
>     at WebRTC.sendSubscribeRequest (/home/andres/js/sipcentric-presence-nodejs/node_modules/@sipcentric/pbx-client/lib/api/webRTC.js:311:21)
>     at WebRTC.resubscribeToUser (/home/andres/js/sipcentric-presence-nodejs/node_modules/@sipcentric/pbx-client/lib/api/webRTC.js:301:10)
>     at /home/andres/js/sipcentric-presence-nodejs/node_modules/@sipcentric/pbx-client/lib/api/webRTC.js:133:16
>     at Map.forEach (<anonymous>)
>     at Timeout._onTimeout (/home/andres/js/sipcentric-presence-nodejs/node_modules/@sipcentric/pbx-client/lib/api/webRTC.js:132:26)
> ```

Closes #5 