### PR TITLE
Hotfix/ Updated presence example to use Sipcentric UA

### DIFF
--- a/examples/presence/README.md
+++ b/examples/presence/README.md
@@ -2,10 +2,11 @@
 
 A basic example of how to use presence.
 
-## Usage
+## Setup config file
+Add your Sipcentric username, password, and customerId to a new file named `config.js`.  See config.example.js
+for reference.
 
-Add your Sipcentric username and password to `config.js`, and set your `customerId` in `index.js`.
-
+## Install dependencies and run the script
 ```bash
 npm install
 npm start

--- a/examples/presence/config.example.js
+++ b/examples/presence/config.example.js
@@ -1,0 +1,5 @@
+module.exports = {
+  CUSTOMER_ID: '',
+  USERNAME: '',
+  PASSWORD: ''
+}


### PR DESCRIPTION
# Hotfix
> Updated presence example to use Sipcentric UA instead of removed presenceWatcher API

This fixes the presence example.  The current example is using the presenceWatcher API which is no longer available.  The following has been done:

* Added config.example.js as reference on how to setup config file
* Updated example to use Sipcentric UA
* Updated README

Closes #8 